### PR TITLE
Improve parsing performance

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
@@ -44,7 +43,7 @@ func appendEntry(entries Entries, newEntry Entry) bool {
 			continue
 		}
 
-		if strings.HasPrefix(newEntry.Data.Session, fmt.Sprintf("%s.", entry.Data.Session)) {
+		if strings.HasPrefix(newEntry.Data.Session, entry.Data.Session+".") {
 			if ok := appendEntry(entry.Children, newEntry); ok {
 				return true
 			} else {


### PR DESCRIPTION
fmt.Sprintf is a slow way to concatenate. On a 50000 line file, the
difference on my machine was 20s vs 64s.